### PR TITLE
Fix 401 error when sub array in parameters

### DIFF
--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -579,7 +579,16 @@ class OAuth extends AbstractAuth
             }
 
             //Add the parameters
-            $oAuthHeaders                    = array_merge($oAuthHeaders, $parameters);
+            $cleanedParameters = $parameters;
+            $possibleKeys = ['filters' => 'filters', 'plainPassword' => 'plainPassword'];
+            if (!empty(array_intersect_key($possibleKeys, $cleanedParameters))){
+                foreach ($possibleKeys as $possibleKey){
+                    if (array_key_exists($possibleKey, $cleanedParameters)) {
+                        unset($cleanedParameters[$possibleKey]);
+                    }
+                }
+            }
+            $oAuthHeaders                    = array_merge($oAuthHeaders, $cleanedParameters);
             $base_info                       = $this->buildBaseString($url, $method, $oAuthHeaders);
             $composite_key                   = $this->getCompositeKey();
             $oAuthHeaders['oauth_signature'] = base64_encode(hash_hmac('sha1', $base_info, $composite_key, true));


### PR DESCRIPTION
Fix 401 error when sub array for filters or plainPassword in parameters

J'ai laissé le "filters" que j'avais vu dans l'issue en plus du "plainPassword" que j'ai ajouté et du coup j'ai un peu remanié le fix.
Testé avec et sans array dans les params. ça fonctionne bien.

J'ai remis à jour la branche 210614_fix_send_file_oauth1 qui est utilisée dans le portail depuis l'api-lib mautic.

Refer to https://github.com/Webmecanik/Portail/issues/606

Refer to https://github.com/mautic/api-library/issues/259